### PR TITLE
Bunch slower aarch64 jobs first to speed up build

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -11,14 +11,14 @@ env:
 
 jobs:
   build:
-    name: ${{ matrix.python }} ${{ matrix.os-name }} ${{ matrix.platform }}
+    name: ${{ matrix.platform }} ${{ matrix.os-name }} ${{ matrix.python }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        platform: [ "aarch64", "x86_64", "i686" ]
         os: [ "ubuntu-20.04", "macos-latest" ]
         python: [ "pypy3.7-7.3.7", "3.7", "3.8", "3.9", "3.10" ]
-        platform: [ "aarch64", "x86_64", "i686" ]
         macos-target: [ "10.10" ]
         exclude:
           - os: "macos-latest"
@@ -70,15 +70,15 @@ jobs:
       #   uses: mxschmitt/action-tmate@v3
 
   build-latest:
-    name: ${{ matrix.python }} ${{ matrix.os-name }} ${{ matrix.platform }} latest
+    name: ${{ matrix.platform }} ${{ matrix.os-name }} ${{ matrix.python }} latest
     runs-on: ${{ matrix.os }}
     if: "!startsWith(github.ref, 'refs/tags/')"
     strategy:
       fail-fast: false
       matrix:
+        platform: [ "aarch64", "x86_64", "i686" ]
         os: [ "ubuntu-20.04", "macos-latest" ]
         python: [ "pypy3.7-7.3.7", "3.7", "3.8", "3.9", "3.10" ]
-        platform: [ "aarch64", "x86_64", "i686" ]
         macos-target: [ "10.10" ]
         exclude:
           - os: "macos-latest"


### PR DESCRIPTION
Updates https://github.com/python-pillow/pillow-wheels/pull/247.

By moving the `platform:` matrix factor first we can get the bottleneck `aarch64` jobs queued up sooner and so let them (and therefore the whole build) finish sooner.

On my fork, this took 2h 21m 57s:

* https://github.com/hugovk/pillow-wheels/actions/runs/1785155556

The baseline took 2h 51m 43s: 

* https://github.com/radarhere/pillow-wheels/actions/runs/1763682103

(Still not convinced whether to ditch faster Travis for this just yet.)
